### PR TITLE
add muli google font

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,4 +1,5 @@
 const { override, fixBabelImports, addLessLoader } = require('customize-cra');
+const modifyVars = require('./src/styles/style-overrides');
 
 // https://ant.design/docs/react/use-with-create-react-app#Advanced-Guides
 
@@ -12,10 +13,8 @@ module.exports = override(
   // https://ant.design/docs/react/use-with-create-react-app#Customize-Theme
   addLessLoader({
     javascriptEnabled: true,
-    modifyVars: {
-      // override any defaults from https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less
-      // must restart the server for changes to take effect
-      '@primary-color': '#1DA57A',
-    },
+    // override any defaults from https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less
+    // must restart the server for changes to take effect
+    modifyVars,
   }),
 );

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+
     <title>MoodMuse</title>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -24,8 +24,11 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-
-    <title>MoodMuse</title>
+    <link
+      href="https://fonts.googleapis.com/css?family=Muli&display=swap"
+      rel="stylesheet"
+    />
+    <title>MoodBloom</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/styles/global-styles.js
+++ b/src/styles/global-styles.js
@@ -1,23 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
-  html, body {
-    height: 100%;
-    width: 100%;
-    line-height: 1.4;
-    box-sizing:border-box;
-  }
-
-  body {
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    width: 100%;
-  }
-
   #root, .App {
     height: 100%;
   }
@@ -30,10 +13,6 @@ const GlobalStyle = createGlobalStyle`
   .App {
     width: 500px;
     max-width: 100%;
-  }
-
-  button {
-    cursor: pointer
   }
 `;
 

--- a/src/styles/style-overrides.js
+++ b/src/styles/style-overrides.js
@@ -1,0 +1,5 @@
+module.exports = {
+  '@font-family':
+    "'Muli',-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB','Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+  // '@primary-color': '#bada55',
+};

--- a/src/styles/style-overrides.js
+++ b/src/styles/style-overrides.js
@@ -1,3 +1,8 @@
+/*
+  These styles used in '../../config-overrides.js to override any defaults from
+  https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less
+  You must restart the server for changes to take effect. */
+
 module.exports = {
   '@font-family':
     "'Muli',-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB','Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif",


### PR DESCRIPTION
# Description
Added Muli from Google Fonts as the default font and a `override-styles.js` for changing any of the default antd styles.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Chill, I'm just adding a font

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
