### PR TITLE
Fix query bug - switch out history object

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "customize-cra": "^0.9.1",
     "date-fns": "^2.8.0",
     "graphql": "^14.5.8",
+    "history": "^4.10.1",
     "less": "^3.10.3",
     "less-loader": "^5.0.0",
     "prop-types": "^15.7.2",

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -2,7 +2,8 @@ import React, { useEffect } from 'react';
 import ApolloClient from 'apollo-boost';
 import { ApolloProvider } from '@apollo/react-hooks';
 import ReactGA from 'react-ga';
-import { Route, Switch, useHistory } from 'react-router-dom';
+import { createBrowserHistory } from 'history';
+import { Route, Switch } from 'react-router-dom';
 import { useAuth0 } from '../../utils/react-auth0-spa';
 import { GRAPHQL_URI } from '../../utils/config';
 import GlobalStyle from '../../styles/global-styles';
@@ -18,7 +19,7 @@ import { MoodsPrevWeekProvider } from '../../contexts/MoodsPrevWeekContext';
 
 function App() {
   const { loading, getTokenSilently } = useAuth0();
-  const history = useHistory();
+  const history = createBrowserHistory();
 
   useEffect(() => {
     // sends pageview hit to GA when path changes

--- a/yarn.lock
+++ b/yarn.lock
@@ -5416,7 +5416,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@^4.9.0:
+history@^4.10.1, history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==


### PR DESCRIPTION
# Description
Replaced history object from react-router with history from history package. Fixes issue where query in week display was being re-run every time the user was routed to the dashboard. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
