### PR TITLE
fixing nav bar border radius to only appear on the top right and left

### DIFF
--- a/src/components/MobileNavBar.js
+++ b/src/components/MobileNavBar.js
@@ -66,7 +66,8 @@ const StyledNavBar = styled.div`
   position: fixed;
   bottom: 0;
   max-width: 500px;
-  border-radius: 14px;
+  border-top-right-radius: 14px;
+  border-top-left-radius: 14px;
 `;
 
 const ButtonWrapper = styled.div`


### PR DESCRIPTION
# Description

Fixes border radius on mobile nav to only have radius on top left and right corners.