### PR TITLE
fix issue #72 with refresh logging the user out

### DIFF
--- a/src/components/Auth/axiosAuth/axios.js
+++ b/src/components/Auth/axiosAuth/axios.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { AXIOS_URI } from '../../../utils/config';
 
-const parseJwt = (token) => {
+export const parseJwt = (token) => {
   try {
     return JSON.parse(atob(token.split('.')[1]));
   } catch (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -10,16 +10,23 @@ import theme from './styles/theme';
 import * as serviceWorker from './utils/serviceWorker';
 import GAListener from './components/GAListener';
 
-// A function that routes the user to the right place after login
-// const onRedirectCallback = (appState) => {
-//   window.history.replaceState(
-//     {},
-//     document.title,
-//     appState && appState.targetUrl
-//       ? appState.targetUrl
-//       : window.location.pathname,
-//   );
-// };
+// replace Router with DebugRouter if you need to debug routes
+
+// class DebugRouter extends Router {
+//   constructor(props) {
+//     super(props);
+//     console.log('initial history is: ', JSON.stringify(this.history, null, 2));
+//     this.history.listen((location, action) => {
+//       console.log(
+//         `The current URL is ${location.pathname}${location.search}${location.hash}`,
+//       );
+//       console.log(
+//         `The last navigation action was ${action}`,
+//         JSON.stringify(this.history, null, 2),
+//       );
+//     });
+//   }
+// }
 
 ReactDOM.render(
   <ThemeProvider theme={theme}>

--- a/src/utils/dataStore.js
+++ b/src/utils/dataStore.js
@@ -7,9 +7,9 @@ import { parseJwt } from '../components/Auth/axiosAuth/axios';
 export const AuthContext = React.createContext();
 export const useAuth = () => useContext(AuthContext);
 export const AuthProvider = ({ children }) => {
-  const [isAuthenticated, setIsAuthenticated] = useState();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const initAuth = async () => {
@@ -20,10 +20,12 @@ export const AuthProvider = ({ children }) => {
         if (userExpDate > Date.now()) {
           setUser(userFromToken);
           setIsAuthenticated(true);
+          setLoading(false);
         } else {
           localStorage.clear();
           setUser(null);
           setIsAuthenticated(false);
+          setLoading(false);
         }
       }
     };

--- a/src/utils/dataStore.js
+++ b/src/utils/dataStore.js
@@ -4,23 +4,28 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { parseJwt } from '../components/Auth/axiosAuth/axios';
 
-// const DEFAULT_REDIRECT_CALLBACK = () =>
-//   window.history.replaceState({}, document.title, window.location.pathname);
-
 export const AuthContext = React.createContext();
 export const useAuth = () => useContext(AuthContext);
 export const AuthProvider = ({ children }) => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState();
   const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    console.log('stuff HERE');
     const initAuth = async () => {
+      setIsAuthenticated(false);
       if (localStorage.token) {
         const userFromToken = parseJwt(localStorage.token);
-        setUser(userFromToken);
-        setLoading(false);
-        setIsAuthenticated(true);
+        const userExpDate = new Date().setSeconds(userFromToken.exp);
+        if (userExpDate > Date.now()) {
+          setUser(userFromToken);
+          setIsAuthenticated(true);
+        } else {
+          localStorage.clear();
+          setUser(null);
+          setIsAuthenticated(false);
+        }
       }
     };
     initAuth();

--- a/src/utils/dataStore.js
+++ b/src/utils/dataStore.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-console */
 /* eslint-disable react/prop-types */
 import React, { useState, useEffect, useContext } from 'react';
+import { parseJwt } from '../components/Auth/axiosAuth/axios';
 
 // const DEFAULT_REDIRECT_CALLBACK = () =>
 //   window.history.replaceState({}, document.title, window.location.pathname);
@@ -9,22 +10,18 @@ import React, { useState, useEffect, useContext } from 'react';
 export const AuthContext = React.createContext();
 export const useAuth = () => useContext(AuthContext);
 export const AuthProvider = ({ children }) => {
-  const [isAuthenticated, setIsAuthenticated] = useState();
-  const [user, setUser] = useState();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const initAuth = async () => {
-      const isAuthenticated = false;
-
-      setIsAuthenticated(isAuthenticated);
-
-      if (isAuthenticated) {
-        const user = null;
-        setUser(user);
+      if (localStorage.token) {
+        const userFromToken = parseJwt(localStorage.token);
+        setUser(userFromToken);
+        setLoading(false);
+        setIsAuthenticated(true);
       }
-
-      setLoading(false);
     };
     initAuth();
     // eslint-disable-next-line

--- a/src/utils/dataStore.js
+++ b/src/utils/dataStore.js
@@ -12,7 +12,6 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    console.log('stuff HERE');
     const initAuth = async () => {
       setIsAuthenticated(false);
       if (localStorage.token) {


### PR DESCRIPTION
# Description

Fixes #72. DataStore.js now checks for token is local storage, if token, it checks if it's expired; if not expired, it uses that to set user and authenticated state. Fixed refresh issue by setting default loading state to true.

## Type of change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)


## Change Status

- [ X ] Complete, tested, ready to review and merge

# How Has This Been Tested?

Manually.

# Checklist

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X ] New and existing unit tests pass locally with my changes
- [ X ] There are no merge conflicts
