### PR TITLE
fixes issue where browser was asking for location data despite being turned off

### DIFF
--- a/src/components/FormViews/FormViews.js
+++ b/src/components/FormViews/FormViews.js
@@ -18,8 +18,8 @@ import ladybug from '../../assets/ladybug.svg';
 
 const FormViews = () => {
   const history = useHistory();
-  const { currentWeather } = useCurrentWeather();
   const { user } = useAuth();
+  const { currentWeather } = useCurrentWeather(user);
   const [addMood] = useMutation(addMoodMutation);
   const { loading, error, data } = useQuery(getUserIdAndLocation, {
     variables: { email: user.email },

--- a/src/containers/Settings/Settings.js
+++ b/src/containers/Settings/Settings.js
@@ -42,6 +42,16 @@ const Settings = () => {
   }, [isSharingLocation, data, loading]);
 
   const toggleLocationPermissions = (checked) => {
+    if (checked && 'geolocation' in navigator) {
+      // if user switches the toggle permission setting to true
+      // and has yet to give permission for the browser to use their location,
+      // fire `getCurrentPosition`, so that we can get the
+      // browser request now even though we aren't using their coords yet.
+      navigator.geolocation.getCurrentPosition((p) => {
+        // eslint-disable-next-line no-unused-vars
+        const { latitude, longitude } = p.coords;
+      });
+    }
     updateIsSharingLocation({
       variables: { id: data.user.id, isSharingLocation: checked },
     });


### PR DESCRIPTION
# Description
- `useCurrentWeather` hook was firing a location request prompt no matter if the user was allowing their location to be shared or not (per the toggle switch in `/settings`)
- Added the `getUserIdAndLocation` query to the `useCurrentWeather` hook in order to check if the user is allowing their location to be shared in settings
- Added a request for location after the user toggles the switch so that they receive the browser prompt for permission after toggling instead of after hitting the add mood button

Fixes #69

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
